### PR TITLE
RPC streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 package-lock.json
+src/*.js

--- a/bin/rpc
+++ b/bin/rpc
@@ -2,6 +2,22 @@
 
 const mq = require("../dist/queue.js");
 const program = require("commander");
+const through2 = require("through2");
+
+const connect = (func) => {
+  mq.connect();
+  const interval = setInterval(() => {
+    if (mq.isConnected()) {
+      clearInterval(interval);
+      func();
+    }
+  }, 100);
+};
+
+const jsonStream = through2.obj(function(chunk, encoding, callback) {
+    this.push(JSON.stringify(chunk, null, 4) + '\n');
+    callback();
+});
 
 program
   .version("1.2.0")
@@ -10,19 +26,22 @@ program
   .option("-d, --data <json>", "payload data (json string)")
   .option("-t, --ttl <milliseconds>", "timeout in milliseconds")
   .option("-s, --silent", "silent mode (don't output anything)")
+  .option("-S, --stream", "use streaming mode")
   .action(function(routingKey) {
     const payload = program.data ? JSON.parse(program.data) : {};
     const ttl = program.ttl ? parseInt(program.ttl) : undefined;
     if (routingKey) {
-      mq.connect();
-      const interval = setInterval(() => {
-        if (mq.isConnected()) {
-          clearInterval(interval);
+      connect(() => {
+        if (program.stream) {
+          mq.stream(routingKey, payload, {}, ttl)
+            .pipe(jsonStream)
+            .pipe(process.stdout);
+        } else {
           mq.rpc(routingKey, payload, {}, ttl)
             .then((msg) => { console.log(msg); process.exit(0); })
-            .catch((err) => { console.error(err); process.exit(1); })
+            .catch((err) => { console.error(err); process.exit(1); });
         }
-      }, 100);
+      });
     } else {
       program.outputHelp();
     }

--- a/bin/rpc
+++ b/bin/rpc
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const mq = require("../src/queue.js");
+const mq = require("../dist/queue.js");
 const program = require("commander");
 
 program

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/node": "^9.6.5",
     "amqp": "^0.2.6",
     "async-mutex": "^0.1.3",
+    "through2": "^2.0.3",
     "uuid": "^3.2.1"
   },
   "devDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compileOnSave": true,
     "compilerOptions": {
+        "outDir": "dist",
         "target": "es2015",
         "module": "commonjs",
         "moduleResolution": "node",


### PR DESCRIPTION
### Problem

The current RPC interface that uses promises has the drawback that it does not acknowledge a message until the message has been completely processed (i.e. the promise has resolved). This behavior makes sense for most types of work because if the handler fails you want another worker to pick up the message instead. So you don't want to acknowledge the message too early.

But when testing the new BankID authentication I noticed that you can only have one active login process at a time. Simply because the RPC messages to the auth service gets queued up and the next message is not handled until the previous message is acknowledged when the BankID login process is finished (which can take up to a minute or more).

### Solution

1. One solution to this is to simply acknowledge the message much earlier (when it is received by the worker). But that will make the delivery of messages less reliable, since a worker can fail and the message will be lost.
2. Another solution is to introduce a "streaming" interface for those RPC calls that need it. The BankID authentication process is one such streaming RPC call that will wait for the result of the call for a very long time (and possibly get multiple status messages while waiting).

In this pull request I have opted for the second solution. But I am not sure if it will end up being the best solution. It is always nice to have a streaming interface so I felt it was worth trying to implement it anyway. But I guess I need a second opinion on what might be the best solution (looking at you @epeld — let me know if you have an opinion).

### Interface

#### Client
```typescript
mq.stream("auth.authenticate", payload, {}, ttl)
  .pipe(jsonStringify)
  .pipe(process.stdout);

// The returned stream uses objectMode = true so will need to be transformed
// into string if output needs to be process.stdout or another destination that
// expects a string or Buffer stream.
```

#### Server
```typescript
mq.worker("auth.authenticate", (msg) => {
  const rs = new stream.Readable();
  rs.push('beep ');
  rs.push('boop\n');
  rs.push(null);
  return rs;
});
```
