### PR TITLE
Add the ./bin/rpc command as an executable in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Message queue library for RPC and PUB/SUB over AMQP.",
   "main": "./dist/queue.js",
   "types": "./dist/queue.d.ts",
+  "bin": {
+    "rpc": "./bin/rpc"
+  },
   "scripts": {
     "test": "make test",
     "compile": "make",


### PR DESCRIPTION
This will make npm install it as a binary in either `./node_modules/.bin/` or `/usr/local/bin/` so that it can be used from a project that has this library as a dependency or be installed globally as a command line tool.