### PR TITLE
Fix handling of missing correlation id header

### DIFF
--- a/dist/queue.js
+++ b/dist/queue.js
@@ -138,7 +138,7 @@ exports.connect = function () {
             const options = {
                 contentType: "application/json",
                 headers: headers ? headers : {},
-                correlationId
+                correlationId: correlationId ? correlationId : uuidv4()
             };
             connection.publish(replyTo, value, options, function (err, msg) {
                 if (err) {

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -198,7 +198,7 @@ export const connect = function() {
       const options: amqp.ExchangePublishOptions = {
         contentType: "application/json",
         headers: headers ? headers : {},
-        correlationId
+        correlationId: correlationId ? correlationId : uuidv4()
       };
       connection.publish(replyTo, value, options,
         function(err?: boolean, msg?: string) {


### PR DESCRIPTION
### Problem

Some RPC clients (the STOMP client for example) does not add a `correlation-id` header to the message which makes the consumer crash because it assumes that if `reply-to` is set, then `correlation-id` will be set too.

### Solution

If `correlation-id` is missing in an RPC request message, instead of just crashing the consumer will now instead generate a correlation id by itself using `uuidv4()` and set it on the reply message.