### PR TITLE
Fix node-amqp crash caused by `undefined` header options

### DIFF
--- a/dist/queue.js
+++ b/dist/queue.js
@@ -164,11 +164,18 @@ exports.connect = function () {
             release();
         });
     };
+    const removeEmptyOptions = (obj) => {
+        Object.keys(obj).forEach(key => (obj[key] && typeof obj[key] === "object") &&
+            removeEmptyOptions(obj[key]) ||
+            (obj[key] === undefined) && delete obj[key]);
+        return obj;
+    };
     const internalPublish = function (msg) {
         return new Promise((resolve, reject) => {
             const exchange = connection
                 .exchange(msg.exchangeName, { confirm: true }, function () {
-                exchange.publish(msg.routingKey, msg.data, msg.options, function (failed, errorMessage) {
+                const options = removeEmptyOptions(msg.options);
+                exchange.publish(msg.routingKey, msg.data, options, function (failed, errorMessage) {
                     if (failed) {
                         reject(new Error(errorMessage));
                     }

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -227,11 +227,21 @@ export const connect = function() {
       });
   };
 
+  const removeEmptyOptions = (obj: any) => {
+    Object.keys(obj).forEach(key =>
+      (obj[key] && typeof obj[key] === "object") &&
+        removeEmptyOptions(obj[key]) ||
+          (obj[key] === undefined) && delete obj[key]
+    );
+    return obj;
+  };
+
   const internalPublish = function(msg: Message) {
     return new Promise((resolve, reject) => {
       const exchange = connection
         .exchange(msg.exchangeName, { confirm: true }, function() {
-          exchange.publish(msg.routingKey, msg.data, msg.options,
+          const options = removeEmptyOptions(msg.options);
+          exchange.publish(msg.routingKey, msg.data, options,
             function(failed, errorMessage) {
               if (failed) {
                 reject(new Error(errorMessage));


### PR DESCRIPTION
## Problem

When trying to publish a message with a header value set to `undefined` the server will crash and reconnect indefinitely since the node-amqp library can't handle message options that are undefined.

## Solution

Ensure that all message options that are undefined or null gets removed before calling `publish()`.