### PR TITLE
Log undefined errors with error level instead of verbose

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -35,6 +35,6 @@ export const errorHandler = (req: Request, logger: Logger) => (
     logger.warn(`${err}`, requestInfo);
   } else {
     req.reject();
-    logger.verbose("rejected", requestInfo);
+    logger.error("rejected", requestInfo);
   }
 };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -34,7 +34,7 @@ export const errorHandler = (req: Request, logger: Logger) => (
     response(req)({ error: err }, { "x-error": err });
     logger.warn(`${err}`, requestInfo);
   } else {
-    req.reject();
+    req.nack();
     logger.error("rejected", requestInfo);
   }
 };

--- a/test/errors_test.ts
+++ b/test/errors_test.ts
@@ -97,8 +97,8 @@ describe("errors", () => {
       it("should reject the request", () =>
         req.reject.called.should.equal(true));
 
-      it("should log a verbose message", () =>
-        (logger.verbose as sinon.SinonStub).called.should.equal(true));
+      it("should log an error message", () =>
+        (logger.error as sinon.SinonStub).called.should.equal(true));
     });
   });
 });


### PR DESCRIPTION
### Problem

Undefined errors are logged with verbose level, but are easily missed due to the low log level.

### Solution

Use the error level instead of verbose.

Co-authored-by: Axel Hellström <axel.hellstrom@insurello.se>
Co-authored-by: Kristian Lundström <kristian.lundstrom@insurello.se>